### PR TITLE
Tweak the relocation + minor refactoring

### DIFF
--- a/src/chain.rs
+++ b/src/chain.rs
@@ -52,7 +52,7 @@ impl Block {
     }
 
     pub fn hash(&self) -> Hash {
-        let mut bytes = [0; 17];
+        let mut bytes = [0; 10];
         bytes[0] = match self.event {
             Event::Live => 0,
             Event::Dead => 1,
@@ -60,7 +60,7 @@ impl Block {
         };
 
         LittleEndian::write_u64(&mut bytes[1..], self.name.0);
-        LittleEndian::write_u64(&mut bytes[9..], self.age);
+        bytes[9] = self.age;
 
         Hash(sha3_256(&bytes))
     }

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -16,9 +16,9 @@ impl Chain {
         Chain { last_live: None }
     }
 
-    pub fn insert(&mut self, event: Event, name: Name, age: Age) {
-        if let Event::Live = event {
-            self.last_live = Some(Block { event, name, age })
+    pub fn insert(&mut self, block: Block) {
+        if let Event::Live = block.event {
+            self.last_live = Some(block)
         }
     }
 
@@ -77,20 +77,7 @@ pub enum Event {
 pub struct Hash([u8; 32]);
 
 impl Hash {
-    pub fn new_from_u64(value: u64) -> Self {
-        let mut value_in = value;
-        let mut result: [u8; 32] = [0; 32];
-        for i in 0..8 {
-            result[7 - i] = (value_in % 256) as u8;
-            value_in = value_in / 256;
-            if value_in == 0 {
-                break;
-            }
-        }
-        Hash(result)
-    }
-
-    pub fn hash(&self) -> Self {
+    pub fn rehash(&self) -> Self {
         Hash(sha3_256(&self.0))
     }
 
@@ -108,14 +95,35 @@ impl Hash {
 
         result as u64
     }
+}
 
-    pub fn to_u64(&self) -> u64 {
+impl From<Name> for Hash {
+    fn from(src: Name) -> Self {
+        let mut value_in = src.0;
+        let mut result: [u8; 32] = [0; 32];
+
+        for i in 0..8 {
+            result[7 - i] = (value_in % 256) as u8;
+            value_in = value_in / 256;
+            if value_in == 0 {
+                break;
+            }
+        }
+
+        Hash(result)
+    }
+}
+
+impl Into<Name> for Hash {
+    fn into(self) -> Name {
         let mut result: u64 = 0;
+
         for i in 0..8 {
             let value = self.0[i];
             result = result * 256 + value as u64;
         }
-        result
+
+        Name(result)
     }
 }
 

--- a/src/log.rs
+++ b/src/log.rs
@@ -23,7 +23,8 @@ pub fn verbosity() -> usize {
 macro_rules! error {
     ($($arg:tt)*) => {
         if $crate::log::verbosity() >= $crate::log::ERROR {
-            println!($($arg)*)
+            use $crate::colored::Colorize;
+            println!("{}", format!($($arg)*).red())
         }
     }
 }
@@ -44,14 +45,6 @@ macro_rules! debug {
             println!($($arg)*)
         }
     }
-}
-
-pub fn important<T: ToString>(msg: T) -> ColoredString {
-    msg.to_string().bright_yellow()
-}
-
-pub fn error<T: ToString>(msg: T) -> ColoredString {
-    msg.to_string().red()
 }
 
 #[allow(unused)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,13 +70,13 @@ fn main() {
             format!("Iteration: {}", format!("{}", i).bold()).green()
         );
 
-        let result = network.tick(i);
+        network.tick(i);
 
         if params.stats_frequency > 0 && i % params.stats_frequency == 0 {
             print_tick_stats(&network, &mut max_prefix_len_diff);
         }
 
-        if !result || !running.load(Ordering::Relaxed) {
+        if !running.load(Ordering::Relaxed) {
             break;
         }
     }
@@ -154,7 +154,7 @@ fn get_params() -> Params {
                 .long("max-relocation-attempts")
                 .help("Maximum number of relocation attempts after a Live event")
                 .takes_value(true)
-                .default_value("5"),
+                .default_value("25"),
         )
         .arg(
             Arg::with_name("MAX_INFANTS_PER_SECTION")

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-type Age = u64;
+type Age = u8;
 
 fn main() {
     let params = get_params();
@@ -238,8 +238,9 @@ fn get_number<T: Number>(matches: &ArgMatches, name: &str) -> T {
 }
 
 trait Number: FromStr {}
-impl Number for usize {}
+impl Number for u8 {}
 impl Number for u64 {}
+impl Number for usize {}
 
 // Use these type aliases instead of the default collections to make sure
 // we use consistent hashing across runs, to enable deterministic results.

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,7 +1,7 @@
 use node::Node;
 use prefix::{Name, Prefix};
 
-/// Network message (RPC),
+/// Network message (RPC).
 /// Note: these do not necessarily correspond to the RPCs of the real network,
 /// because this simulation abstracts lot of the real stuff away.
 #[derive(Debug)]

--- a/src/message.rs
+++ b/src/message.rs
@@ -13,14 +13,18 @@ pub enum Request {
     Dead(Name),
     /// Initiate a merge into the section with the given prefix.
     Merge(Prefix),
-    /// Request whether a node can be relocated to a prefix matching section. (src, target, node)
-    RelocateRequest(Prefix, Name, Name),
+    /// Request to relocate a node to a section matching `dst`.
+    RelocateRequest {
+        src: Prefix,
+        dst: Name,
+        node_name: Name,
+    },
     /// Relocate the given node to section.
     Relocate(Node),
-    /// Accept of Relocation. (dst, node)
-    RelocateAccept(Prefix, Name),
-    /// Reject of Relocation. (target, node)
-    RelocateReject(Name, Name),
+    /// Accept the relocation request.
+    RelocateAccept { dst: Name, node_name: Name },
+    /// Reject the relocation request.
+    RelocateReject { dst: Name, node_name: Name },
 }
 
 #[derive(Debug)]
@@ -31,8 +35,14 @@ pub enum Response {
     Split(Section, Section, Prefix),
     /// Reject an attempt to join a section.
     Reject(Node),
-    /// Request whether a node can be relocated to a prefix matching section. (src, target, node)
-    RelocateRequest(Prefix, Name, Name),
+    /// Request from `src` to relocate a node to a section matching `dst`.
+    RelocateRequest {
+        src: Prefix,
+        dst: Name,
+        node_name: Name,
+    },
+    /// Relocate the given node to a section matching `dst`.
+    Relocate { dst: Name, node: Node },
     /// Send a request to the section with the given prefix.
     Send(Prefix, Request),
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,48 +1,45 @@
 use node::Node;
 use prefix::{Name, Prefix};
-use section::Section;
 
-/// Network message (RPC).
+/// Network message (RPC),
 /// Note: these do not necessarily correspond to the RPCs of the real network,
-/// because this simulation abstracts of the real stuff away.
+/// because this simulation abstracts lot of the real stuff away.
 #[derive(Debug)]
-pub enum Request {
-    /// A node joins the network.
-    Live(Node),
-    /// A node left the network (disconnected).
-    Dead(Name),
-    /// Initiate a merge into the section with the given prefix.
-    Merge(Prefix),
-    /// Request to relocate a node to a section matching `dst`.
-    RelocateRequest {
-        src: Prefix,
-        dst: Name,
-        node_name: Name,
-    },
-    /// Relocate the given node to section.
-    Relocate(Node),
-    /// Accept the relocation request.
-    RelocateAccept { dst: Name, node_name: Name },
-    /// Reject the relocation request.
-    RelocateReject { dst: Name, node_name: Name },
+pub enum Message {
+    /// Request to relocate a node with the given name to the given target.
+    RelocateRequest { node_name: Name, target: Name },
+    /// Positive reponse to a relocate request.
+    RelocateAccept { node_name: Name, target: Name },
+    /// Negative response to a relocate request.
+    RelocateReject { node_name: Name, target: Name },
+    /// Actually relocate the node.
+    RelocateCommit { node: Node, target: Name },
+    /// Cancel a previously accepted relocate request (due to the node to be
+    /// relocated disconnecting)
+    RelocateCancel { node_name: Name, target: Name },
 }
 
+impl Message {
+    pub fn target(&self) -> Name {
+        match *self {
+            Message::RelocateRequest { target, .. } |
+            Message::RelocateCommit { target, .. } |
+            Message::RelocateCancel { target, .. } => target,
+            Message::RelocateAccept { node_name, .. } |
+            Message::RelocateReject { node_name, .. } => node_name,
+        }
+    }
+}
+
+/// Network action.
 #[derive(Debug)]
-pub enum Response {
-    /// Merge sections.
-    Merge(Section, Prefix),
-    /// Split section.
-    Split(Section, Section, Prefix),
+pub enum Action {
     /// Reject an attempt to join a section.
     Reject(Node),
-    /// Request from `src` to relocate a node to a section matching `dst`.
-    RelocateRequest {
-        src: Prefix,
-        dst: Name,
-        node_name: Name,
-    },
-    /// Relocate the given node to a section matching `dst`.
-    Relocate { dst: Name, node: Node },
-    /// Send a request to the section with the given prefix.
-    Send(Prefix, Request),
+    /// Merge all descendants of the prefix.
+    Merge(Prefix),
+    /// Split the section.
+    Split(Prefix),
+    /// Send a message.
+    Send(Message),
 }

--- a/src/network.rs
+++ b/src/network.rs
@@ -1,10 +1,9 @@
 use HashMap;
 use log;
-use message::{Request, Response};
-use node::{self, Node};
+use message::{Action, Message};
+use node;
 use params::Params;
-use prefix::{Name, Prefix};
-use random;
+use prefix::Prefix;
 use section::Section;
 use stats::{Distribution, Stats};
 use std::ops::AddAssign;
@@ -28,15 +27,29 @@ impl Network {
         }
     }
 
-    /// Execute single iteration of the simulation. Returns `true` if the
-    /// simulation is running successfuly so far, `false` if it failed and should
-    /// be stopped.
-    pub fn tick(&mut self, iterations: u64) -> bool {
-        self.generate_random_messages();
-        let stats = self.handle_messages();
+    /// Execute single iteration of the simulation.
+    pub fn tick(&mut self, iteration: u64) {
+        let mut actions = Vec::new();
+        let mut stats = TickStats::new();
+
+        for section in self.sections.values_mut() {
+            section.prepare();
+        }
+
+        loop {
+            for section in self.sections.values_mut() {
+                actions.extend(section.tick(&self.params));
+            }
+
+            if actions.is_empty() {
+                break;
+            }
+
+            stats += self.handle_actions(&mut actions)
+        }
 
         self.stats.record(
-            iterations,
+            iteration,
             self.sections
                 .values()
                 .map(|section| section.nodes().len() as u64)
@@ -48,9 +61,7 @@ impl Network {
             stats.rejections,
         );
 
-        let _ = self.check_section_sizes();
-
-        true
+        let _ = self.validate();
     }
 
     pub fn stats(&self) -> &Stats {
@@ -84,130 +95,80 @@ impl Network {
         Distribution::new(self.sections.keys().map(|prefix| prefix.len() as u64))
     }
 
-    fn generate_random_messages(&mut self) {
-        let mut adds = 0;
-        let mut drops = 0;
 
-        for section in self.sections.values_mut() {
-            if section.has_incoming_relocation() {
-                continue;
-            }
-
-            if random::gen() {
-                add_random_node(&self.params, section);
-                adds += 1;
-
-                if drop_random_node(&self.params, section) {
-                    drops += 1;
-                }
-            } else {
-                if drop_random_node(&self.params, section) {
-                    drops += 1;
-                }
-
-                add_random_node(&self.params, section);
-                adds += 1;
-            }
-        }
-
-        info!(
-            "Random Adds: {} Drops: {}",
-            log::important(adds),
-            log::important(drops)
-        );
-    }
-
-    fn handle_messages(&mut self) -> TickStats {
-        let mut responses = Vec::new();
+    fn handle_actions(&mut self, actions: &mut Vec<Action>) -> TickStats {
         let mut stats = TickStats::new();
 
-        loop {
-            for section in self.sections.values_mut() {
-                responses.extend(section.handle_requests(&self.params));
-            }
-
-            if responses.is_empty() {
-                break;
-            }
-
-            stats += self.handle_responses(&mut responses)
-        }
-
-        stats
-    }
-
-    fn handle_responses(&mut self, responses: &mut Vec<Response>) -> TickStats {
-        let mut stats = TickStats::new();
-
-        for response in responses.drain(..) {
-            match response {
-                Response::Merge(section, old_prefix) => {
-                    self.sections
-                        .entry(section.prefix())
-                        .or_insert_with(|| {
-                            stats.merges += 1;
-                            Section::new(section.prefix())
-                        })
-                        .merge(&self.params, section);
-                    let _ = self.sections.remove(&old_prefix);
+        for action in actions.drain(..) {
+            match action {
+                Action::Reject(_) => {
+                    stats.rejections += 1;
                 }
-                Response::Split(section0, section1, old_prefix) => {
+                Action::Merge(target) => {
+                    let sources: Vec<_> = self.sections
+                        .keys()
+                        .filter(|prefix| prefix.is_descendant(&target))
+                        .cloned()
+                        .collect();
+
+                    if sources.is_empty() {
+                        continue;
+                    }
+
+                    let sources: Vec<_> = sources
+                        .into_iter()
+                        .map(|source| self.sections.remove(&source).unwrap())
+                        .collect();
+
+                    stats.merges += 1;
+
+                    let section = self.sections.entry(target).or_insert_with(
+                        || Section::new(target),
+                    );
+                    for source in sources {
+                        section.merge(&self.params, source);
+                    }
+                }
+                Action::Split(source) => {
                     stats.splits += 1;
 
-                    let prefix0 = section0.prefix();
-                    let prefix1 = section1.prefix();
+                    let source = if let Some(section) = self.sections.remove(&source) {
+                        section
+                    } else {
+                        // Pre-split section does not exists due to being already merged
+                        // or split.
+                        debug!("Pre-split section {} not found", log::prefix(&source));
+                        continue;
+                    };
+
+                    let (target0, target1) = source.split(&self.params);
+                    let prefix0 = target0.prefix();
+                    let prefix1 = target1.prefix();
 
                     assert!(
-                        self.sections.insert(prefix0, section0).is_none(),
+                        self.sections.insert(prefix0, target0).is_none(),
                         "section with prefix [{}] already exists",
                         prefix0
                     );
                     assert!(
-                        self.sections.insert(prefix1, section1).is_none(),
+                        self.sections.insert(prefix1, target1).is_none(),
                         "section with prefix [{}] already exists",
                         prefix1
                     );
-
-                    let _ = self.sections.remove(&old_prefix);
                 }
-                Response::Reject(_) => {
-                    stats.rejections += 1;
-                }
-                Response::RelocateRequest {
-                    src,
-                    dst,
-                    node_name,
-                } => {
-                    let section = self.find_matching_section(dst);
-                    section.receive(Request::RelocateRequest {
-                        src,
-                        dst,
-                        node_name,
+                Action::Send(message) => {
+                    let target = message.target();
+                    if let Some(section) = self.sections.values_mut().find(|section| {
+                        section.prefix().matches(target)
                     })
-                }
-                Response::Relocate { dst, node } => {
-                    stats.relocations += 1;
-                    let section = self.find_matching_section(dst);
-                    section.receive(Request::Relocate(node))
-                }
-                Response::Send(prefix, request) => {
-                    match request {
-                        Request::Merge(target_prefix) => {
-                            // The receiver of `Merge` might not exists, because
-                            // it might have already split. So send the request
-                            // to every section with matching prefix.
-                            for section in self.sections.values_mut().filter(|section| {
-                                prefix.is_ancestor(&section.prefix())
-                            })
-                            {
-                                section.receive(Request::Merge(target_prefix))
-                            }
-                        }
-                        Request::Relocate(node) => {
+                    {
+                        if let Message::RelocateCommit { .. } = message {
                             stats.relocations += 1;
-                            self.send(prefix, Request::Relocate(node));
                         }
-                        _ => self.send(prefix, request),
+
+                        section.receive(message)
+                    } else {
+                        panic!("No section maching {:?} found", target)
                     }
                 }
             }
@@ -216,77 +177,39 @@ impl Network {
         stats
     }
 
-    fn find_matching_section(&mut self, name: Name) -> &mut Section {
-        if let Some(section) = self.sections.values_mut().find(|section| {
-            section.prefix().matches(name)
-        })
-        {
-            section
-        } else {
-            unreachable!()
+    fn validate(&self) {
+        for section in self.sections.values() {
+            if section.nodes().len() > self.params.max_section_size {
+                let prefixes = section.prefix().split();
+                let count0 = node::count_matching_adults(
+                    &self.params,
+                    prefixes[0],
+                    section.nodes().values(),
+                );
+                let count1 = node::count_matching_adults(
+                    &self.params,
+                    prefixes[1],
+                    section.nodes().values(),
+                );
+
+                error!(
+                    "{}: too many nodes: {} (adults per subsections: [..0]: {}, [..1]: {})",
+                    log::prefix(&section.prefix()),
+                    section.nodes().len(),
+                    count0,
+                    count1,
+                );
+            }
+
+            let incoming = section.incoming_relocations();
+            if incoming.len() > 0 {
+                panic!(
+                    "{}: relocation cache not cleared: {:?}",
+                    log::prefix(&section.prefix()),
+                    incoming,
+                )
+            }
         }
-    }
-
-    fn send(&mut self, prefix: Prefix, request: Request) {
-        if let Some(section) = self.sections.get_mut(&prefix) {
-            section.receive(request)
-        } else {
-            debug!(
-                "{} {} {} {}",
-                log::error("Section with prefix"),
-                log::prefix(&prefix),
-                log::error("not found for request"),
-                log::message(&request),
-            );
-        }
-    }
-
-    fn check_section_sizes(&self) -> bool {
-        if let Some(section) = self.sections.values().find(|section| {
-            section.nodes().len() > self.params.max_section_size
-        })
-        {
-            let prefixes = section.prefix().split();
-            let count0 =
-                node::count_matching_adults(&self.params, prefixes[0], section.nodes().values());
-            let count1 =
-                node::count_matching_adults(&self.params, prefixes[1], section.nodes().values());
-
-            error!(
-                "{}: {}: {} (adults per subsections: [..0]: {}, [..1]: {})",
-                log::prefix(&section.prefix()),
-                log::error("too many nodes"),
-                section.nodes().len(),
-                count0,
-                count1,
-            );
-            false
-        } else {
-            true
-        }
-    }
-}
-
-// Generate random `Live` request in the given section.
-fn add_random_node(params: &Params, section: &mut Section) {
-    let name = section.prefix().substituted_in(random::gen());
-    section.receive(Request::Live(Node::new(name, params.init_age)));
-}
-
-// Generate random `Dead` request in the given section.
-fn drop_random_node(_params: &Params, section: &mut Section) -> bool {
-    let name = node::by_age(section.nodes().values())
-        .into_iter()
-        .find(|node| {
-            random::gen_bool_with_probability(node.drop_probability())
-        })
-        .map(|node| node.name());
-
-    if let Some(name) = name {
-        section.receive(Request::Dead(name));
-        true
-    } else {
-        false
     }
 }
 

--- a/src/network.rs
+++ b/src/network.rs
@@ -112,6 +112,11 @@ impl Network {
                         .collect();
 
                     if sources.is_empty() {
+                        // No pre-merge section exists due to being already merged.
+                        debug!(
+                            "Pre-merge sections not found (to be merged to {})",
+                            log::prefix(&target)
+                        );
                         continue;
                     }
 
@@ -204,9 +209,18 @@ impl Network {
             let incoming = section.incoming_relocations();
             if incoming.len() > 0 {
                 panic!(
-                    "{}: relocation cache not cleared: {:?}",
+                    "{}: incoming relocation cache not cleared: {:?}",
                     log::prefix(&section.prefix()),
                     incoming,
+                )
+            }
+
+            let outgoing = section.outgoing_relocations();
+            if outgoing.len() > 0 {
+                panic!(
+                    "{}: outgoing relocation cache not cleared: {:?}",
+                    log::prefix(&section.prefix()),
+                    outgoing,
                 )
             }
         }

--- a/src/network.rs
+++ b/src/network.rs
@@ -155,6 +155,11 @@ impl Network {
                         //
                         // This situation is valid, so it's OK to ignore the missing
                         // sections here.
+                        //
+                        // On the other hand, this line should never be reached due to
+                        // `Split` being emitted more than once, because split can
+                        // only be triggered by join or relocation, and those happen
+                        // at most once per section tick.
                         debug!("Pre-split section {} not found", log::prefix(&source));
                         continue;
                     };

--- a/src/network.rs
+++ b/src/network.rs
@@ -112,7 +112,12 @@ impl Network {
                         .collect();
 
                     if sources.is_empty() {
-                        // No pre-merge section exists due to being already merged.
+                        // Merge action with the same target can be potentially
+                        // emitted multiple times per tick.
+                        // This can happen for example when both pre-merge sections
+                        // lose a node in the same tick, triggering merge in both of
+                        // them. That's why not finding any pre-merge section is
+                        // not an error and can be safely ignored.
                         debug!(
                             "Pre-merge sections not found (to be merged to {})",
                             log::prefix(&target)
@@ -140,10 +145,11 @@ impl Network {
                     let source = if let Some(section) = self.sections.remove(&source) {
                         section
                     } else {
-                        // Pre-split section does not exists due to being already merged
-                        // or split.
-                        debug!("Pre-split section {} not found", log::prefix(&source));
-                        continue;
+                        // Split can be triggered only by join or relocation,
+                        // which can happen at most once per section tick, so
+                        // a split can also happen at most once, so it should not
+                        // be possible to reach this line.
+                        panic!("Pre-split section {} not found", log::prefix(&source));
                     };
 
                     let (target0, target1) = source.split(&self.params);

--- a/src/node.rs
+++ b/src/node.rs
@@ -48,7 +48,7 @@ impl Node {
     }
 
     pub fn increment_age(&mut self) {
-        self.age = self.age.saturating_add(1);
+        self.age = self.age.checked_add(1).expect("age overflow")
     }
 
     /// Returns the probability this node will be dropped.

--- a/src/params.rs
+++ b/src/params.rs
@@ -11,9 +11,9 @@ pub struct Params {
     /// Number of nodes to form a complete group.
     pub group_size: usize,
     /// Age of newly joined node.
-    pub init_age: u64,
+    pub init_age: u8,
     /// Age at which a node becomes adult.
-    pub adult_age: u64,
+    pub adult_age: u8,
     /// Maximum number of nodes a section can have before the simulation fails.
     pub max_section_size: usize,
     /// Maximum number of reocation attempts after a `Live` event.

--- a/src/section.rs
+++ b/src/section.rs
@@ -10,7 +10,7 @@ use random;
 use std::collections::hash_map::{self, Entry};
 use std::fmt;
 use std::mem;
-use std::u64;
+use std::u8;
 
 pub struct Section {
     prefix: Prefix,
@@ -502,7 +502,7 @@ impl Section {
             return None;
         }
 
-        candidates.sort_by_key(|node| u64::MAX - node.age());
+        candidates.sort_by_key(|node| u8::MAX - node.age());
 
         let age = candidates[0].age();
         let index = candidates
@@ -521,7 +521,7 @@ impl Section {
     fn relocation_candidates(&self, hash: &Hash) -> Vec<&Node> {
         // The actual formula is: `hash % 2^age == 0`, the following is equivalent
         // but more efficient:
-        let trailing_zeros = hash.trailing_zeros();
+        let trailing_zeros = hash.trailing_zeros() as u8;
         self.nodes
             .values()
             .filter(|node| node.age() <= trailing_zeros)

--- a/src/section.rs
+++ b/src/section.rs
@@ -2,35 +2,36 @@ use HashMap;
 use HashSet;
 use chain::{Block, Chain, Event, Hash};
 use log;
-use message::{Request, Response};
+use message::{Action, Message};
 use node::{self, Node};
 use params::Params;
 use prefix::{Name, Prefix};
 use random;
+use std::collections::hash_map::{self, Entry};
 use std::fmt;
 use std::mem;
 use std::u64;
 
 pub struct Section {
     prefix: Prefix,
-    state: State,
     nodes: HashMap<Name, Node>,
     chain: Chain,
-    requests: Vec<Request>,
+    messages: Vec<Message>,
     incoming_relocations: HashMap<Name, Name>,
-    outgoing_relocations: HashSet<Name>,
+    outgoing_relocations: HashMap<Name, Name>,
+    churned: bool,
 }
 
 impl Section {
     pub fn new(prefix: Prefix) -> Self {
         Section {
             prefix,
-            state: State::Stable,
             nodes: HashMap::default(),
             chain: Chain::new(),
-            requests: Vec::new(),
+            messages: Vec::new(),
             incoming_relocations: HashMap::default(),
-            outgoing_relocations: HashSet::default(),
+            outgoing_relocations: HashMap::default(),
+            churned: false,
         }
     }
 
@@ -47,163 +48,304 @@ impl Section {
         node::count_adults(params, self.nodes.values()) >= params.group_size
     }
 
-    pub fn has_incoming_relocation(&self) -> bool {
-        !self.incoming_relocations.is_empty()
+    pub fn incoming_relocations(&self) -> hash_map::Keys<Name, Name> {
+        self.incoming_relocations.keys()
     }
 
-    pub fn receive(&mut self, request: Request) {
-        self.requests.push(request)
+    /// Call this at the begining of each simulation tick to reset some internal state.
+    pub fn prepare(&mut self) {
+        self.churned = false
     }
 
-    pub fn handle_requests(&mut self, params: &Params) -> Vec<Response> {
-        let mut responses = Vec::new();
+    /// Single simulation iteration of this section.
+    /// Note: there can be multiple section ticks per network tick.
+    pub fn tick(&mut self, params: &Params) -> Vec<Action> {
+        let mut actions = Vec::new();
+        let mut relocated_in = false;
 
-        for request in mem::replace(&mut self.requests, Vec::new()) {
+        for message in mem::replace(&mut self.messages, Vec::new()) {
             debug!(
                 "{}: received {}",
                 log::prefix(&self.prefix),
-                log::message(&request)
+                log::message(&message)
             );
 
-            responses.extend(match request {
-                Request::Live(node) => self.handle_live(params, node),
-                Request::Dead(name) => self.handle_dead(params, name),
-                Request::Merge(prefix) => self.handle_merge(params, prefix),
-                Request::RelocateRequest {
-                    src,
-                    dst,
-                    node_name,
-                } => self.handle_relocate_request(params, src, dst, node_name),
-                Request::RelocateAccept { dst, node_name } => {
-                    self.handle_relocate_accept(dst, node_name)
+            match message {
+                Message::RelocateRequest { node_name, target } => {
+                    actions.push(if relocated_in {
+                        Action::Send(Message::RelocateReject { node_name, target })
+                    } else {
+                        self.handle_relocate_request(params, node_name, target)
+                    })
                 }
-                Request::RelocateReject { dst, node_name } => {
-                    self.handle_relocate_reject(dst, node_name)
+                Message::RelocateAccept { node_name, target } => {
+                    actions.extend(self.handle_relocate_accept(node_name, target))
                 }
-                Request::Relocate(node) => self.handle_relocate(params, node),
-            })
+                Message::RelocateReject { node_name, target } => {
+                    actions.extend(self.handle_relocate_reject(params, node_name, target));
+                }
+                Message::RelocateCommit { node, .. } => {
+                    if let Some(action) = self.handle_relocate_commit(params, node) {
+                        relocated_in = true;
+                        actions.push(action);
+                    }
+                }
+                Message::RelocateCancel { node_name, .. } => self.handle_relocate_cancel(node_name),
+            }
         }
 
-        responses
+        if !self.churned && !relocated_in {
+            if self.incoming_relocations.is_empty() {
+                if random::gen() {
+                    actions.extend(self.random_join(params));
+                    actions.extend(self.random_drop(params));
+                } else {
+                    actions.extend(self.random_drop(params));
+                    actions.extend(self.random_join(params));
+                }
+            } else {
+                actions.extend(self.random_drop(params));
+            }
+
+            self.churned = true;
+        }
+
+        actions
+    }
+
+    /// Receive a message. The messages are actually handled later, during `tick`.
+    pub fn receive(&mut self, message: Message) {
+        self.messages.push(message)
+    }
+
+    pub fn split(self, params: &Params) -> (Section, Section) {
+        let prefixes = self.prefix.split();
+
+        debug!(
+            "{}: splitting into {} and {}",
+            log::prefix(&self.prefix),
+            log::prefix(&prefixes[0]),
+            log::prefix(&prefixes[1]),
+        );
+
+        let mut section0 = Section::new(prefixes[0]);
+        let mut section1 = Section::new(prefixes[1]);
+
+        section0.chain = self.chain.clone();
+        section1.chain = self.chain;
+
+        // Nodes
+        let (nodes0, nodes1) = split(self.nodes, prefixes[0], prefixes[1], |&(name, _)| name);
+
+        section0.nodes = nodes0;
+        section0.update_elders(params);
+
+        section1.nodes = nodes1;
+        section1.update_elders(params);
+
+        // Outgoing relocations
+        let (nodes0, nodes1) = split(
+            self.outgoing_relocations,
+            prefixes[0],
+            prefixes[1],
+            |&(name, _)| name,
+        );
+
+        section0.outgoing_relocations = nodes0;
+        section1.outgoing_relocations = nodes1;
+
+        // Incoming relocations
+        let (nodes0, nodes1) = split(
+            self.incoming_relocations,
+            prefixes[0],
+            prefixes[1],
+            |&(_, target)| target,
+        );
+
+        section0.incoming_relocations = nodes0;
+        section1.incoming_relocations = nodes1;
+
+        // Messages
+        for message in self.messages {
+            let target = message.target();
+
+            if prefixes[0].matches(target) {
+                section0.messages.push(message);
+            } else if prefixes[1].matches(target) {
+                section1.messages.push(message);
+            } else {
+                unreachable!()
+            }
+        }
+
+        (section0, section1)
     }
 
     pub fn merge(&mut self, params: &Params, other: Section) {
-        assert_eq!(self.prefix, other.prefix);
+        debug!(
+            "{}: merging {} adults from {}",
+            log::prefix(&self.prefix),
+            node::count_adults(params, other.nodes.values()),
+            log::prefix(&other.prefix),
+        );
+
         self.chain.extend(other.chain);
         self.nodes.extend(other.nodes);
-        self.requests.extend(other.requests);
+        self.messages.extend(other.messages);
         self.incoming_relocations.extend(other.incoming_relocations);
         self.outgoing_relocations.extend(other.outgoing_relocations);
-        let _ = self.update_elders(params, false);
+        self.update_elders(params);
     }
 
-    /// Handle new node attempt to join us.
-    fn handle_live(&mut self, params: &Params, node: Node) -> Vec<Response> {
-        if let Some(prefix) = self.forward(node.name()) {
-            return vec![Response::Send(prefix, Request::Live(node))];
-        }
-
+    fn handle_live(&mut self, params: &Params, mut node: Node) -> Option<Action> {
         // During startup, nodes joining as adult (age of 5), and no relocation.
-        let startup = self.prefix == Prefix::EMPTY;
-
-        let new_node = if startup {
-            Node::new(node.name(), params.adult_age)
+        if self.prefix == Prefix::EMPTY {
+            node = Node::new(node.name(), params.adult_age)
         } else if node.is_infant(params) &&
                    node::count_infants(params, self.nodes.values()) >=
                        params.max_infants_per_section
         {
-            return self.reject_node(node);
-        } else {
-            node
-        };
+            return Some(self.reject_node(node));
+        }
 
-        let age = new_node.age();
-        let name = new_node.name();
-        let is_adult = new_node.is_adult(params);
+        let name = node.name();
+        let age = node.age();
+        let is_adult = node.is_adult(params);
 
-        self.add_node(new_node);
-        // A relocated adult shall only trigger relocate once.
-        // It's promotion shall not trigger relocation.
-        let _ = self.update_elders(params, false);
+        self.join_node(node);
+        self.update_elders(params);
 
-        let responses = self.try_split(params);
-        if !responses.is_empty() {
-            responses
-        } else if is_adult && !startup {
+        if let Some(action) = self.try_split(params) {
+            Some(action)
+        } else if is_adult {
             self.try_relocate(params, Block::new(Event::Live, name, age))
         } else {
-            Vec::new()
+            None
         }
     }
 
-    fn handle_dead(&mut self, params: &Params, name: Name) -> Vec<Response> {
+    fn handle_dead(&mut self, params: &Params, name: Name) -> Vec<Action> {
+        let mut actions = Vec::new();
+
         if let Some(node) = self.drop_node(name) {
-            let mut responses = self.update_elders(params, true);
-            responses.extend(self.try_merge(params));
-            if node.is_adult(params) {
-                if let Some(last_live) = self.chain.last_live() {
-                    responses.extend(self.try_relocate(params, last_live));
-                }
-            }
-            responses
-        } else {
-            Vec::new()
-        }
-    }
-
-    fn handle_merge(&mut self, params: &Params, parent: Prefix) -> Vec<Response> {
-        match self.state {
-            State::Merging(old_parent) => {
-                if old_parent.is_ancestor(&parent) {
-                    return Vec::new();
-                } else {
-                    return vec![Response::Send(old_parent, Request::Merge(parent))];
-                }
-            }
-            State::Splitting => {
-                let prefixes = self.prefix.split();
-
+            if let Some(target) = self.outgoing_relocations.remove(&node.name()) {
                 debug!(
-                    "{}: split in progress. Forwarding request to {}, {}",
+                    "{}: cancelling relocation of {} (node dropped)",
                     log::prefix(&self.prefix),
-                    log::prefix(&prefixes[0]),
-                    log::prefix(&prefixes[1])
+                    log::name(&node.name())
                 );
 
-                return vec![
-                    Response::Send(prefixes[0], Request::Merge(parent)),
-                    Response::Send(prefixes[1], Request::Merge(parent)),
-                ];
+                actions.push(Action::Send(Message::RelocateCancel {
+                    node_name: node.name(),
+                    target,
+                }));
             }
-            _ => (),
+
+            actions.extend(self.try_merge(params));
+
+            if node.is_adult(params) {
+                self.update_elders(params);
+                if let Some(block) = self.chain.last_live() {
+                    actions.extend(self.try_relocate(params, block));
+                }
+            }
         }
 
-        debug!(
-            "{}: merging {} adults into {}",
-            log::prefix(&self.prefix),
-            node::count_adults(params, self.nodes.values()),
-            log::prefix(&parent),
-        );
-
-        let mut section = Section::new(parent);
-        section.chain = self.chain.clone();
-        section.nodes = mem::replace(&mut self.nodes, HashMap::default());
-
-        self.state = State::Merging(parent);
-
-        vec![Response::Merge(section, self.prefix)]
+        actions
     }
 
-    fn handle_relocate(&mut self, params: &Params, node: Node) -> Vec<Response> {
-        if let Some(prefix) = self.forward(node.name()) {
-            return vec![Response::Send(prefix, Request::Relocate(node))];
+    fn handle_relocate_request(
+        &mut self,
+        params: &Params,
+        node_name: Name,
+        target: Name,
+    ) -> Action {
+        if !self.incoming_relocations.is_empty() || self.nodes.len() >= params.max_section_size {
+            debug!(
+                "{}: rejecting relocation of {}",
+                log::prefix(&self.prefix),
+                log::name(&node_name),
+            );
+
+            Action::Send(Message::RelocateReject { node_name, target })
+        } else {
+            debug!(
+                "{}: accepting relocation of {}",
+                log::prefix(&self.prefix),
+                log::name(&node_name),
+            );
+
+            let _ = self.incoming_relocations.insert(node_name, target);
+            Action::Send(Message::RelocateAccept { node_name, target })
+        }
+    }
+
+    fn handle_relocate_accept(&mut self, node_name: Name, target: Name) -> Option<Action> {
+        if self.outgoing_relocations.remove(&node_name).is_some() {
+            if let Some(mut node) = self.nodes.remove(&node_name) {
+                node.increment_age();
+                if node.is_elder() {
+                    node.demote();
+                    self.chain.insert(
+                        Block::new(Event::Dead, node_name, node.age()),
+                    );
+                }
+
+                return Some(Action::Send(Message::RelocateCommit { node, target }));
+            }
         }
 
+        None
+    }
+
+    fn handle_relocate_reject(
+        &mut self,
+        params: &Params,
+        node_name: Name,
+        target: Name,
+    ) -> Option<Action> {
+        match self.outgoing_relocations.entry(node_name) {
+            Entry::Occupied(mut entry) => {
+                // Do not retry the relocation during startup or if it would trigger merge.
+                if self.prefix == Prefix::EMPTY ||
+                    node::count_adults(params, self.nodes.values()) <= params.group_size
+                {
+                    debug!(
+                        "{}: cancelling relocation of {} (not beneficial anymore)",
+                        log::prefix(&self.prefix),
+                        log::name(&entry.key())
+                    );
+
+                    entry.remove();
+                    None
+                } else {
+                    // Calculate new relocation target.
+                    let target = Hash::from(target).rehash().into();
+
+                    debug!(
+                        "{}: re-initiating relocation of {} to {}",
+                        log::prefix(&self.prefix),
+                        log::name(&entry.key()),
+                        log::name(&target)
+                    );
+
+                    *entry.get_mut() = target;
+                    Some(Action::Send(Message::RelocateRequest { node_name, target }))
+                }
+            }
+            Entry::Vacant(_) => None,
+        }
+    }
+
+    fn handle_relocate_commit(&mut self, params: &Params, node: Node) -> Option<Action> {
         if self.incoming_relocations.remove(&node.name()).is_none() {
-            return Vec::new();
+            error!(
+                "{}: cannot commit relocation of {}: not found in incoming relocation cache",
+                log::prefix(&self.prefix),
+                log::name(&node.name())
+            );
+            return None;
         }
-
-        let new_name = random::gen();
 
         // Pick the new node name so it would fall into the subsection with
         // fewer members, to keep the section balanced.
@@ -211,6 +353,7 @@ impl Section {
         let count0 = node::count_matching_adults(params, prefixes[0], self.nodes.values());
         let count1 = node::count_matching_adults(params, prefixes[1], self.nodes.values());
 
+        let new_name = random::gen();
         let new_name = if count0 < count1 {
             prefixes[0].substituted_in(new_name)
         } else {
@@ -218,66 +361,42 @@ impl Section {
         };
 
         debug!(
-            "relocating {} -> {} to {}",
+            "{}: relocating {} -> {}",
+            log::prefix(&self.prefix),
             log::name(&node.name()),
             log::name(&new_name),
-            log::prefix(&self.prefix),
         );
 
         self.handle_live(params, Node::new(new_name, node.age()))
     }
 
-    fn handle_relocate_request(
-        &mut self,
-        params: &Params,
-        src: Prefix,
-        dst: Name,
-        node_name: Name,
-    ) -> Vec<Response> {
-        if !self.incoming_relocations.is_empty() || self.nodes.len() >= params.max_section_size {
-            vec![
-                Response::Send(src, Request::RelocateReject { dst, node_name }),
-            ]
-        } else {
-            let _ = self.incoming_relocations.insert(node_name, dst);
-            vec![
-                Response::Send(src, Request::RelocateAccept { dst, node_name }),
-            ]
-        }
+    fn handle_relocate_cancel(&mut self, node_name: Name) {
+        let _ = self.incoming_relocations.remove(&node_name);
     }
 
-    fn handle_relocate_accept(&mut self, dst: Name, node_name: Name) -> Vec<Response> {
-        if self.outgoing_relocations.remove(&node_name) {
-            if let Some(mut node) = self.nodes.remove(&node_name) {
-                node.increment_age();
-                if node.is_elder() {
-                    node.demote();
-                    self.chain.insert(Event::Dead, node_name, node.age());
-                }
-
-                return vec![Response::Relocate { dst, node }];
-            }
-        }
-
-        Vec::new()
+    // Simulate random node attempt to join this section.
+    fn random_join(&mut self, params: &Params) -> Option<Action> {
+        let name = self.prefix.substituted_in(random::gen());
+        self.handle_live(params, Node::new(name, params.init_age))
     }
 
-    fn handle_relocate_reject(&self, dst: Name, node_name: Name) -> Vec<Response> {
-        if self.outgoing_relocations.contains(&node_name) {
-            let dst = Name(Hash::new_from_u64(dst.0).hash().to_u64());
-            vec![
-                Response::RelocateRequest {
-                    src: self.prefix,
-                    dst,
-                    node_name,
-                },
-            ]
+    // Simulate random node disconnecting.
+    fn random_drop(&mut self, params: &Params) -> Vec<Action> {
+        let name = node::by_age(self.nodes.values())
+            .into_iter()
+            .find(|node| {
+                random::gen_bool_with_probability(node.drop_probability())
+            })
+            .map(|node| node.name());
+
+        if let Some(name) = name {
+            self.handle_dead(params, name)
         } else {
             Vec::new()
         }
     }
 
-    fn try_split(&mut self, params: &Params) -> Vec<Response> {
+    fn try_split(&mut self, params: &Params) -> Option<Action> {
         // We can only split if both section post-split would remain with at least
         // 2 * GROUP_SIZE - QUORUM adults.
 
@@ -292,8 +411,8 @@ impl Section {
 
         let num_adults0 = node::count_matching_adults(params, prefixes[0], self.nodes.values());
         let num_adults1 = node::count_matching_adults(params, prefixes[1], self.nodes.values());
-
         let limit = 2 * params.group_size - params.quorum();
+
         if num_adults0 >= limit && num_adults1 >= limit {
             debug!(
                 "{}: initiating split into {} and {}",
@@ -302,120 +421,80 @@ impl Section {
                 log::prefix(&prefixes[1])
             );
 
-            let mut section0 = Section::new(prefixes[0]);
-            let mut section1 = Section::new(prefixes[1]);
-
-            section0.chain = self.chain.clone();
-            section1.chain = self.chain.clone();
-
-            // Nodes
-            let (nodes0, nodes1) = split(
-                self.nodes.drain(),
-                prefixes[0],
-                prefixes[1],
-                |&(name, _)| name,
-            );
-
-            section0.nodes = nodes0;
-            let _ = section0.update_elders(params, false);
-
-            section1.nodes = nodes1;
-            let _ = section1.update_elders(params, false);
-
-            // Outgoing relocations
-            let (nodes0, nodes1) = split(
-                self.outgoing_relocations.drain(),
-                prefixes[0],
-                prefixes[1],
-                |&name| name,
-            );
-
-            section0.outgoing_relocations = nodes0;
-            section1.outgoing_relocations = nodes1;
-
-            // Incoming relocations
-            let (nodes0, nodes1) = split(
-                self.incoming_relocations.drain(),
-                prefixes[0],
-                prefixes[1],
-                |&(_, dst)| dst,
-            );
-
-            section0.incoming_relocations = nodes0;
-            section1.incoming_relocations = nodes1;
-
-            self.state = State::Splitting;
-
-            vec![Response::Split(section0, section1, self.prefix)]
+            Some(Action::Split(self.prefix))
         } else {
-            Vec::new()
+            None
         }
     }
 
-    fn try_merge(&mut self, params: &Params) -> Vec<Response> {
+    fn try_merge(&mut self, params: &Params) -> Option<Action> {
         if self.prefix == Prefix::EMPTY {
             // We are the root section - nobody to merge with.
-            return Vec::new();
+            return None;
         }
 
         if node::count_adults(params, self.nodes.values()) >= params.group_size {
             // We have enough adults, not need to merge.
-            return Vec::new();
+            return None;
         }
 
         let sibling = self.prefix.sibling();
-        let parent = self.prefix.shorten();
+        let target = self.prefix.shorten();
 
         debug!(
             "{}: initiating merge with {} into {}",
             log::prefix(&self.prefix),
             log::prefix(&sibling),
-            log::prefix(&parent)
+            log::prefix(&target)
         );
 
-        vec![
-            Response::Send(self.prefix, Request::Merge(parent)),
-            Response::Send(sibling, Request::Merge(parent)),
-        ]
+        Some(Action::Merge(target))
     }
 
-    fn try_relocate(&mut self, params: &Params, live_block: Block) -> Vec<Response> {
+    fn try_relocate(&mut self, params: &Params, live_block: Block) -> Option<Action> {
+        // Do not relocate during startup.
+        if self.prefix == Prefix::EMPTY {
+            return None;
+        }
+
         // If the relocation would trigger merge, don't relocate.
         if node::count_adults(params, self.nodes.values()) <= params.group_size {
-            return Vec::new();
+            return None;
         }
 
         // When there is alread node waiting for relocation, don't relocate.
         if !self.outgoing_relocations.is_empty() {
-            return Vec::new();
+            return None;
         }
 
         let mut hash = live_block.hash();
 
         for _ in 0..params.max_relocation_attempts {
-            if let Some(node_name) = self.check_relocate(params, &hash) {
-                let _ = self.outgoing_relocations.insert(node_name);
-                let dst = Name(hash.to_u64());
-                return vec![
-                    Response::RelocateRequest {
-                        src: self.prefix,
-                        dst,
-                        node_name,
-                    },
-                ];
+            if let Some(node_name) = self.check_relocate(&hash) {
+                let target = hash.into();
+                let _ = self.outgoing_relocations.insert(node_name, target);
+
+                debug!(
+                    "{}: initiating relocation of {} to {}",
+                    log::prefix(&self.prefix),
+                    log::name(&node_name),
+                    log::name(&target)
+                );
+
+                return Some(Action::Send(Message::RelocateRequest { node_name, target }));
             } else {
-                hash = hash.hash();
+                hash = hash.rehash();
             }
         }
 
-        Vec::new()
+        None
     }
 
-    fn check_relocate(&self, params: &Params, hash: &Hash) -> Option<Name> {
+    fn check_relocate(&self, hash: &Hash) -> Option<Name> {
         // Find the oldest node for which `hash % 2^age == 0`.
         // If there is more than one, apply the tie-breaking rule.
 
-        let mut candidates = self.relocation_candidates(params, hash);
+        let mut candidates = self.relocation_candidates(hash);
         if candidates.is_empty() {
             return None;
         }
@@ -436,21 +515,9 @@ impl Section {
         }
     }
 
-    fn relocation_candidates(&self, _params: &Params, hash: &Hash) -> Vec<&Node> {
-        // Formula: `hash % 2^age == 0`
-
-        // let hash = BigUint::from_bytes_le(&hash[..]);
-        // let two = BigUint::from(2u32);
-        // let zero = BigUint::from(0u32);
-
-        // self.nodes
-        //     .values()
-        //     .filter(|node| {
-        //         hash.clone() % pow(two.clone(), node.age() as usize) == zero
-        //     })
-        //     .collect()
-
-        // This is equivalent but more efficient:
+    fn relocation_candidates(&self, hash: &Hash) -> Vec<&Node> {
+        // The actual formula is: `hash % 2^age == 0`, the following is equivalent
+        // but more efficient:
         let trailing_zeros = hash.trailing_zeros();
         self.nodes
             .values()
@@ -458,47 +525,7 @@ impl Section {
             .collect()
     }
 
-    fn update_elders(&mut self, params: &Params, relocate: bool) -> Vec<Response> {
-        let old: HashSet<_> = self.nodes
-            .values()
-            .filter(|node| node.is_elder())
-            .map(|node| node.name())
-            .collect();
-        let new: HashSet<_> = {
-            let mut new = node::by_age(self.nodes.values());
-            new.reverse();
-            new.into_iter()
-                .take(params.group_size)
-                .map(|node| node.name())
-                .collect()
-        };
-
-        let mut promoted_nodes = vec![];
-        for node in self.nodes.values_mut() {
-            let old = old.contains(&node.name());
-            let new = new.contains(&node.name());
-
-            if old && !new {
-                node.demote();
-                self.chain.insert(Event::Gone, node.name(), node.age());
-            }
-
-            if new && !old {
-                node.promote();
-                self.chain.insert(Event::Live, node.name(), node.age());
-                promoted_nodes.push(Node::new(node.name(), node.age()));
-            }
-        }
-
-        if relocate && promoted_nodes.len() == 1 {
-            let node = promoted_nodes.first().unwrap();
-            self.try_relocate(params, Block::new(Event::Live, node.name(), node.age()))
-        } else {
-            Vec::new()
-        }
-    }
-
-    fn add_node(&mut self, node: Node) {
+    fn join_node(&mut self, node: Node) {
         debug!(
             "{}: added {}",
             log::prefix(&self.prefix),
@@ -507,13 +534,13 @@ impl Section {
         let _ = self.nodes.insert(node.name(), node);
     }
 
-    fn reject_node(&self, node: Node) -> Vec<Response> {
+    fn reject_node(&self, node: Node) -> Action {
         debug!(
             "{}: rejected {}",
             log::prefix(&self.prefix),
             log::name(&node.name())
         );
-        vec![Response::Reject(node)]
+        Action::Reject(node)
     }
 
     fn drop_node(&mut self, name: Name) -> Option<Node> {
@@ -529,33 +556,38 @@ impl Section {
         }
     }
 
-    // If we are splitting or merging, return the prefix to forward a request to.
-    fn forward(&self, name: Name) -> Option<Prefix> {
-        match self.state {
-            State::Stable => None,
-            State::Splitting => {
-                for prefix in &self.prefix.split() {
-                    if prefix.matches(name) {
-                        debug!(
-                            "{}: split in progress. Forwarding request to {}",
-                            log::prefix(&self.prefix),
-                            log::prefix(prefix)
-                        );
+    // Promote/demote nodes so only the `GROUP_SIZE` oldest nodes are elders.
+    fn update_elders(&mut self, params: &Params) {
+        let old: HashSet<_> = self.nodes
+            .values()
+            .filter(|node| node.is_elder())
+            .map(|node| node.name())
+            .collect();
+        let new: HashSet<_> = {
+            let mut new = node::by_age(self.nodes.values());
+            new.reverse();
+            new.into_iter()
+                .take(params.group_size)
+                .map(|node| node.name())
+                .collect()
+        };
 
-                        return Some(*prefix);
-                    }
-                }
+        for node in self.nodes.values_mut() {
+            let old = old.contains(&node.name());
+            let new = new.contains(&node.name());
 
-                unreachable!()
-            }
-            State::Merging(prefix) => {
-                debug!(
-                    "{}: merge in progress. Forwarding request to {}",
-                    log::prefix(&self.prefix),
-                    log::prefix(&prefix)
+            if old && !new {
+                node.demote();
+                self.chain.insert(
+                    Block::new(Event::Gone, node.name(), node.age()),
                 );
+            }
 
-                Some(prefix)
+            if new && !old {
+                node.promote();
+                self.chain.insert(
+                    Block::new(Event::Live, node.name(), node.age()),
+                );
             }
         }
     }
@@ -565,13 +597,6 @@ impl fmt::Debug for Section {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         write!(fmt, "Section({})", self.prefix)
     }
-}
-
-#[derive(Clone, Copy, Eq, PartialEq)]
-enum State {
-    Stable,
-    Splitting,
-    Merging(Prefix),
 }
 
 fn break_ties(mut nodes: Vec<&Node>) -> Option<Name> {

--- a/src/section.rs
+++ b/src/section.rs
@@ -52,6 +52,10 @@ impl Section {
         self.incoming_relocations.keys()
     }
 
+    pub fn outgoing_relocations(&self) -> hash_map::Keys<Name, Name> {
+        self.outgoing_relocations.keys()
+    }
+
     /// Call this at the begining of each simulation tick to reset some internal state.
     pub fn prepare(&mut self) {
         self.churned = false
@@ -339,12 +343,11 @@ impl Section {
 
     fn handle_relocate_commit(&mut self, params: &Params, node: Node) -> Option<Action> {
         if self.incoming_relocations.remove(&node.name()).is_none() {
-            error!(
+            panic!(
                 "{}: cannot commit relocation of {}: not found in incoming relocation cache",
                 log::prefix(&self.prefix),
                 log::name(&node.name())
             );
-            return None;
         }
 
         // Pick the new node name so it would fall into the subsection with

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -16,22 +16,32 @@ impl Distribution {
     where
         I: IntoIterator<Item = u64>,
     {
-        let mut min = u64::MAX;
-        let mut max = 0;
-        let mut avg = 0;
-        let mut num = 0;
+        let mut values = values.into_iter();
 
-        for value in values {
-            min = cmp::min(min, value);
-            max = cmp::max(max, value);
-            avg += value;
-            num += 1;
-        }
+        if let Some(value) = values.next() {
+            let mut min = value;
+            let mut max = value;
+            let mut avg = value;
+            let mut num = 1;
 
-        Distribution {
-            min,
-            max,
-            avg: avg as f64 / num as f64,
+            for value in values {
+                min = cmp::min(min, value);
+                max = cmp::max(max, value);
+                avg += value;
+                num += 1;
+            }
+
+            Distribution {
+                min,
+                max,
+                avg: avg as f64 / num as f64,
+            }
+        } else {
+            Distribution {
+                min: 0,
+                max: 0,
+                avg: 0.0,
+            }
         }
     }
 }
@@ -58,7 +68,7 @@ impl fmt::Display for Distribution {
 
 #[derive(Clone, Copy, Default)]
 pub struct Sample {
-    iterations: u64,
+    iteration: u64,
     nodes: u64,
     sections: u64,
     merges: u64,
@@ -71,14 +81,14 @@ impl fmt::Debug for Sample {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         write!(
             fmt,
-            "{{ iterations: {}, \
+            "{{ iteration: {}, \
             nodes: {}, \
             sections: {}, \
             merges: {}, \
             splits: {}, \
             relocations: {} \
             rejections: {} }}",
-            self.iterations,
+            self.iteration,
             self.nodes,
             self.sections,
             self.merges,
@@ -92,14 +102,14 @@ impl fmt::Debug for Sample {
 impl fmt::Display for Sample {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         writeln!(fmt,
-            "Iterations:  {:>8}\n\
+            "Iteration:   {:>8}\n\
              Nodes:       {:>8}\n\
              Sections:    {:>8}\n\
              Merges:      {:>8}\n\
              Splits:      {:>8}\n\
              Relocations: {:>8}\n\
              Rejections:  {:>8}",
-            self.iterations,
+            self.iteration,
             self.nodes,
             self.sections,
             self.merges,
@@ -131,7 +141,7 @@ impl Stats {
 
     pub fn record(
         &mut self,
-        iterations: u64,
+        iteration: u64,
         total_nodes: u64,
         total_sections: u64,
         merges: u64,
@@ -145,7 +155,7 @@ impl Stats {
         self.total_rejections += rejections;
 
         self.samples.push(Sample {
-            iterations,
+            iteration,
             nodes: total_nodes,
             sections: total_sections,
             merges: self.total_merges,
@@ -172,7 +182,7 @@ impl Stats {
                 write!(
                 file,
                 "{} {} {} {} {} {} {}\n",
-                sample.iterations,
+                sample.iteration,
                 sample.nodes,
                 sample.sections,
                 sample.merges,


### PR DESCRIPTION
- do not add or drop nodes to/from sections that have ongoing incoming relocation
- forward `Relocate` to post-split/post-merge sections
- minor refactoring